### PR TITLE
chore: add dependency packages

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,7 @@
 
   <depend>urdf</depend>
   <depend>xacro</depend>
+  <depend>robot_state_publisher</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
add  the `package.xml` file to add a missing dependency.
